### PR TITLE
Fixed a ClassCastException on startup

### DIFF
--- a/src/zedly/zenchantments/Config.java
+++ b/src/zedly/zenchantments/Config.java
@@ -199,7 +199,7 @@ public class Config {
                         CustomEnchantment ench = (CustomEnchantment) cl.newInstance();
                         if (configInfo.containsKey(ench.loreName)) {
                             LinkedHashMap<String, Object> data = configInfo.get(ench.loreName);
-                            ench.probability = (float) (double) data.get("Probability");
+                            ench.probability = Float.valueOf(data.get("Probability"));
                             ench.loreName = (String) data.get("Name");
                             if (data.containsValue("Max Level")) {
                                 ench.maxLevel = (int) data.get("Max Level");


### PR DESCRIPTION
* Fixed a ClassCastException: Cannot cast java.lang.Integer to java.lang.Double

(I am not aware if there are any more issues as such, but you really shouldn't use Objects like this. Organize the structure of the lists to prevent CCE's like this)